### PR TITLE
Makefile: remove rabbitmq version fixing

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test-setup egg-info test
 
 test-setup: egg-info
-	docker pull rabbitmq:3.6.6
+	docker pull rabbitmq
 	docker pull wazopbx/wait
 	docker pull wazopbx/wazo-auth-mock
 	docker build --pull -t wazopbx/wazo-websocketd ..


### PR DESCRIPTION
reason: it was fixed in 2017 because it was causing issues. If it still
cause issues, we will try to fix the issue.