### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "9497"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to integration-test Docker Compose configuration; primary risk is unintended behavior differences if tests previously relied on a newer `rabbitmq:latest` image.
> 
> **Overview**
> Updates `integration_tests/assets/docker-compose.yml` to **pin RabbitMQ to `rabbitmq:3`** instead of the untagged `rabbitmq` image, making integration test environments more deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d76b64d6727c020b50578d83fb860f84daa4b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->