### PR TITLE
RB-43 feat(session): expose user & tenant identity in session logs

### DIFF
--- a/wazo_websocketd/session.py
+++ b/wazo_websocketd/session.py
@@ -163,7 +163,11 @@ class Session:
                 self._tenant_uuid,
             )
         except Exception:
-            logger.exception('unexpected exception during websocket session run:')
+            logger.exception(
+                'unexpected exception during websocket session run: (user=%s tenant=%s)',
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(1011)
 
     async def _run(self):

--- a/wazo_websocketd/session.py
+++ b/wazo_websocketd/session.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -57,7 +57,13 @@ class SessionFactory:
         try:
             await session.run()
         finally:
-            logger.info('websocket session terminated %s', remote_address)
+            user_uuid, tenant_uuid = session.user_identity()
+            logger.info(
+                'websocket session terminated %s (user=%s tenant=%s)',
+                remote_address,
+                user_uuid,
+                tenant_uuid,
+            )
 
 
 class Session:
@@ -86,36 +92,76 @@ class Session:
         self._started = False
         self._bus_service: BusService = bus_service
         self._consumer: BusConsumer = None  # type: ignore[assignment]
+        self._user_uuid: str | None = None
+        self._tenant_uuid: str | None = None
+
+    def user_identity(self) -> tuple[str | None, str | None]:
+        return self._user_uuid, self._tenant_uuid
 
     async def run(self):
         try:
             await self._run()
         except NoTokenError:
-            logger.info('closing websocket connection: no token')
+            logger.info(
+                'closing websocket connection: no token (user=%s tenant=%s)',
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(self._CLOSE_CODE_NO_TOKEN_ID, 'no token')
         except AuthenticationExpiredError:
-            logger.info('closing websocket connection: authentication expired')
+            logger.info(
+                'closing websocket connection: authentication expired (user=%s tenant=%s)',
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(
                 self._CLOSE_CODE_AUTH_EXPIRED, 'authentication expired'
             )
         except AuthenticationError as e:
-            logger.info('closing websocket connection: authentication failed: %s', e)
+            logger.info(
+                'closing websocket connection: authentication failed: %s (user=%s tenant=%s)',
+                e,
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(self._CLOSE_CODE_AUTH_FAILED, 'authentication failed')
         except SessionProtocolError as e:
-            logger.info('closing websocket connection: session protocol error: %s', e)
+            logger.info(
+                'closing websocket connection: session protocol error: %s (user=%s tenant=%s)',
+                e,
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(self._CLOSE_CODE_PROTOCOL_ERROR)
         except UnsupportedVersionError:
-            logger.info('closing websocket connection: protocol version unknown')
+            logger.info(
+                'closing websocket connection: protocol version unknown (user=%s tenant=%s)',
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(self._CLOSE_CODE_PROTOCOL_ERROR)
         except BusConnectionLostError:
-            logger.info('closing websocket connection: bus connection lost')
+            logger.info(
+                'closing websocket connection: bus connection lost (user=%s tenant=%s)',
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(1011, 'bus connection lost')
         except BusConnectionError:
-            logger.info('closing websocket connection: bus connection error')
+            logger.info(
+                'closing websocket connection: bus connection error (user=%s tenant=%s)',
+                self._user_uuid,
+                self._tenant_uuid,
+            )
             await self._ws.close(1011, 'bus connection error')
         except websockets.ConnectionClosed as e:
             # also raised when the ws_server is closed
-            logger.info('websocket connection closed with code %s', e.code)
+            logger.info(
+                'websocket connection closed with code %s (user=%s tenant=%s)',
+                e.code,
+                self._user_uuid,
+                self._tenant_uuid,
+            )
         except Exception:
             logger.exception('unexpected exception during websocket session run:')
             await self._ws.close(1011)
@@ -128,6 +174,8 @@ class Session:
 
         token_id = _extract_token_id(self._ws, self._path)
         token = await self._authenticator.get_token(token_id)
+        self._user_uuid = token['metadata'].get('uuid')
+        self._tenant_uuid = token['metadata'].get('tenant_uuid')
 
         async with await self._bus_service.create_consumer(token) as self._consumer:
             await self._ws.send(

--- a/wazo_websocketd/tests/test_session.py
+++ b/wazo_websocketd/tests/test_session.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -7,7 +7,41 @@ from unittest.mock import Mock
 from hamcrest import assert_that, equal_to
 
 from ..exception import NoTokenError
-from ..session import _extract_token_id
+from ..session import Session, _extract_token_id
+
+_CONFIG = {'websocket': {'ping_interval': 30}}
+
+
+def _make_session():
+    return Session(
+        _CONFIG,
+        Mock(),
+        Mock(),
+        Mock(),
+        Mock(),
+        Mock(),
+        '/',
+    )
+
+
+class TestSessionUserIdentity(unittest.TestCase):
+    def test_no_identity_before_authentication(self):
+        session = _make_session()
+
+        user_uuid, tenant_uuid = session.user_identity()
+
+        assert_that(user_uuid, equal_to(None))
+        assert_that(tenant_uuid, equal_to(None))
+
+    def test_identity_after_authentication(self):
+        session = _make_session()
+        session._user_uuid = 'user-uuid-1234'
+        session._tenant_uuid = 'tenant-uuid-5678'
+
+        user_uuid, tenant_uuid = session.user_identity()
+
+        assert_that(user_uuid, equal_to('user-uuid-1234'))
+        assert_that(tenant_uuid, equal_to('tenant-uuid-5678'))
 
 
 class TestExtractTokenID(unittest.TestCase):


### PR DESCRIPTION
why: help debugging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only logging changes with no impact on authentication, protocol handling, or bus behavior.
> 
> **Overview**
> **Websocket session logs now include user and tenant UUIDs** when a connection ends or closes for a known reason, to make production debugging easier.
> 
> `Session` keeps `_user_uuid` and `_tenant_uuid` from `token['metadata']` after the initial `get_token` in `_run`, exposes them via `user_identity()`, and `SessionFactory` logs them on session termination. All `run()` close-path `logger.info` / `logger.exception` messages append `(user=%s tenant=%s)` (often `None` if auth never completed).
> 
> Unit tests cover `user_identity()` before authentication and when the fields are set manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84e770082898508e8f6b0372e12d19a7a6f94bce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->