### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 23.10
 
 * Default configuration for `auth_check_strategy` has been changed from `static`

--- a/etc/wazo-websocketd/config.yml
+++ b/etc/wazo-websocketd/config.yml
@@ -31,8 +31,7 @@
 ## wazo-auth (authentication daemon) connection settings.
 #auth:
 #  host: localhost
-#  port: 9497
-#  prefix: null
+#  port: 80
 #  https: false
 
 ## Event bus (AMQP) connection settings

--- a/integration_tests/assets/etc/wazo-websocketd/conf.d/20-wrong-auth-server.yml
+++ b/integration_tests/assets/etc/wazo-websocketd/conf.d/20-wrong-auth-server.yml
@@ -1,2 +1,4 @@
 auth:
   host: inexisting-auth.fix-resolvd-systemd-behaviour
+  port: 9497
+  prefix: null

--- a/integration_tests/assets/etc/wazo-websocketd/conf.d/50-base.yml
+++ b/integration_tests/assets/etc/wazo-websocketd/conf.d/50-base.yml
@@ -4,6 +4,8 @@ websocket:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
   username: websocketd-service
   password: websocketd-password
 

--- a/wazo_websocketd/config.py
+++ b/wazo_websocketd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -23,8 +23,7 @@ _DEFAULT_CONFIG = {
     'user': 'wazo-websocketd',
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-websocketd-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production auth depends on nginx and wazo-auth routing being deployed first; mis-timed rollout would break internal auth (404). Config-only change with clear test overrides.
> 
> **Overview**
> **Default wazo-auth connectivity** now targets nginx’s internal entry point (`localhost:80`) instead of the wazo-auth service port (`9497`). Python defaults in `config.py` and the commented example in `etc/wazo-websocketd/config.yml` are updated together so deployed config matches runtime defaults.
> 
> The explicit `prefix: null` default is **removed** from Python defaults; `wazo-auth-client` is expected to use `/api/auth` when prefix is unset.
> 
> **Integration test overrides** in `50-base.yml` and `20-wrong-auth-server.yml` now set `port: 9497` and `prefix: null` explicitly, since those stacks talk to auth directly without nginx.
> 
> Changelog **26.09** documents the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44e151346de740024e0e1992aa0a5ed2609315a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->